### PR TITLE
Past Cohort Change + Emoji change + Emoji Key Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,6 @@
 ### **[💮Kendall💮](https://github.com/kendall-hill)**
 ### **[🌃Jordin🪐](https://github.com/Jordin221)**
 
-
-## Meet the 2025 Cohort
-### **[🧸Kayla🌸](https://github.com/kaybcodes)**
-### **[🎀༘Kailea💋](https://github.com/kailealee)**
-### **🍀[Nia](https://github.com/npNSU) 🔰**
-### **📸[Devon](https://github.com/devon3583)🐆**
-### **[🐜Amante'🛳️](https://github.com/awood0727)**
-### **[🪞Jakiya🪞](https://github.com/jakbrownbytes)** 
-### **⭐️[Kaylee](https://github.com/purpleskates123)🎨**
-### **[😎Denzel👌](https://github.com/dcaine125)**
-### **🎸[Silas](https://github.com/SilasVM) 📸**
-#### [2025 Cohort Expectations](https://github.com/emmet0r/contributor-catalyst/blob/main/2025-Exepctations.md)
-
 </br>
 
 ## Past Cohorts

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ### **🎸🌱[Silas](https://github.com/SilasVM)📸🎆**
 ### **[⚡Kameron🏂🏿](https://github.com/kameron-ctrl)**
 ### **[🎱Nijel⚔️](https://github.com/Nijel05).**
-### **[☠️Amario☠️](https://github.com/aiamerson)**
+### **[☠️Amario💎](https://github.com/aiamerson)**
 ### **[🕷️Xavier🕺🏾](https://github.com/xmcgee26)**
 ### **[🕷️Amari👽](https://github.com/MarsGray)**
 ### **[😎Jaden🎸](https://github.com/JadenLunsford)**

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To get yourself added here, head over to your closed pull request and leave the 
 ```plaintext
 @all-contributors please add @<username> for <contributions>
 ```
-[Emoji Key](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)  
+[Emoji Key](https://allcontributors.org/en/reference/emoji-key/)  
 
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->


### PR DESCRIPTION
I deleted the "Meet the 2025 Cohorts" section, which was a duplicate, with them being moved to the past cohort section already. I also changed one of my skull emojis into a diamond emoji. I also added the new link to the Emoji Key