### PR TITLE
Add responsible technology practices to the Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -41,6 +41,8 @@ community include:
   and learning from the experience
 * Focusing on what is best not just for us as individuals, but for the overall
   community
+* Recognizing the real-world impact of technology and encouraging responsible, secure,
+  and accessible innovation
 
 The following behaviors are considered harassment and are unacceptable within our community:
 


### PR DESCRIPTION
Summary
This pull request proposes adding language about responsible technology practices to the Contributor Catalyst Code of Conduct.

Changes Made
- Added language encouraging responsible technology practices
- Encouraged contributors to think about the real-world impact of the technology they create

Why This Matters
The things we build can have a real impact on people and communities. I wanted to encourage contributors to think beyond the code itself and consider how their work affects security, accessibility, privacy, and the world around them.

fixed #149