### PR TITLE
Added author and github link in the 2026 expectations doc 

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To get yourself added here, head over to your closed pull request and leave the 
 ```plaintext
 @all-contributors please add @<username> for <contributions>
 ```
-[Emoji Key](https://github.com/all-contributors/all-contributors/blob/master/docs/emoji-key.md)  
+[Emoji Key](https://allcontributors.org/en/reference/emoji-key/)  
 
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->

--- a/expectations-docs/2026-Expectations.md
+++ b/expectations-docs/2026-Expectations.md
@@ -82,3 +82,4 @@
 - Build a stronger portfolio and improve my networking skills to help me secure a well-paying job.
 ## Authors
 [Mariah](https://github.com/riahdollxo)
+[Nije'l](https://github.com/Nijel05) 


### PR DESCRIPTION
Added myself as an author and my  github link under contributors in the 2026 expectations doc. 